### PR TITLE
Change make_unique() to make_shared when initializing DriveEnumerator Ata in vtStorAtaInit() function.

### DIFF
--- a/vtStorAta/Common.props
+++ b/vtStorAta/Common.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)vtStorAtaProtocol\Platform\Windows;$(SolutionDir);$(ProjectDir);$(ProjectDir)Platform\Windows\;$(SolutionDir)\StorageUtility\Windows;$(SolutionDir)Common;$(SolutionDir)Common\Platform\x86x64;$(SolutionDir)Common\Platform\x86x64\Windows;$(SolutionDir)vtStor;$(SolutionDir)vtStor\Platform\Windows;$(SolutionDir)StorageUtility</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)vtStorAtaProtocol\Platform\Windows;$(SolutionDir)vtStorAtaProtocol;$(SolutionDir);$(ProjectDir);$(ProjectDir)Platform\Windows\;$(SolutionDir)\StorageUtility\Windows;$(SolutionDir)Common;$(SolutionDir)Common\Platform\x86x64;$(SolutionDir)Common\Platform\x86x64\Windows;$(SolutionDir)vtStor;$(SolutionDir)vtStor\Platform\Windows;$(SolutionDir)StorageUtility</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>VT_STOR_ATA_DLL_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>

--- a/vtStorAta/vtStorAta.cpp
+++ b/vtStorAta/vtStorAta.cpp
@@ -27,5 +27,5 @@ namespace vtStor
 
 void vtStorAtaInit(std::shared_ptr<vtStor::cDriveEnumeratorInterface>& DriveEnumerator)
 {
-    DriveEnumerator = std::make_unique<vtStor::cDriveEnumeratorAta>();
+    DriveEnumerator = std::make_shared<vtStor::cDriveEnumeratorAta>();
 }

--- a/vtStorScsi/vtStorScsi.cpp
+++ b/vtStorScsi/vtStorScsi.cpp
@@ -27,5 +27,5 @@ namespace vtStor
 
 void vtStorScsiInit(std::shared_ptr<vtStor::cDriveEnumeratorInterface>& DriveEnumerator)
 {
-    DriveEnumerator = std::make_unique<vtStor::cDriveEnumeratorScsi>();
+    DriveEnumerator = std::make_shared<vtStor::cDriveEnumeratorScsi>();
 }


### PR DESCRIPTION
Change make_unique() to make_shared when initializing DriveEnumerator Ata in vtStorAtaInit() function.
