### PR TITLE
Fix vtStor be able to run on RAID mode on Windows 10

### DIFF
--- a/StorageUtility/Windows/StorageUtility.cpp
+++ b/StorageUtility/Windows/StorageUtility.cpp
@@ -241,6 +241,7 @@ bool IsAtaDeviceBus( sStorageAdapterProperty StorageDeviceProperty )
 {
     switch ( StorageDeviceProperty.BusType )
     {
+        case BusTypeRAID:
         case BusTypeAta:
         case BusTypeSata:
         {


### PR DESCRIPTION
Edit checking bus (for ata) to catch BusTypeRaid of devices when OS was set up to RAID mode
