### PR TITLE
DeviceHandle must be consistent between Windows and Linux

### DIFF
--- a/Common/Platform/x86x64/Linux/PlatformDefines.h
+++ b/Common/Platform/x86x64/Linux/PlatformDefines.h
@@ -49,7 +49,7 @@ using tstring = std::string;
 
 #define INVALID_FILE_DESCRIPTOR -1
 #define IOCTL_SG_IO_ERROR -1
-#define INVALID_PHYSICAL_DISC_NUMBER 0
+#define INVALID_PHYSICAL_DISC_NUMBER 0xFFFFFFFF
 
 namespace vtStor
 {

--- a/Common/Platform/x86x64/Windows/PlatformDefines.h
+++ b/Common/Platform/x86x64/Windows/PlatformDefines.h
@@ -1,6 +1,6 @@
 /*
 <License>
-Copyright 2015 Virtium Technology
+Copyright 2016 Virtium Technology
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ limitations under the License.
 
 #include <string>
 #include <Windows.h>
+
+#include "BusType.h"
 
 #ifdef _UNICODE
 #define    __STORAPITEXT( s ) L##s
@@ -77,7 +79,12 @@ using tstring = std::string;
 
 namespace vtStor
 {
-    using DeviceHandle = HANDLE;
+    struct sDeviceHandle
+    {
+        HANDLE Handle;
+        eBusType Bus;
+    };
+    using DeviceHandle = sDeviceHandle;
 }
 
 #endif

--- a/StorageUtility/Linux/StorageUtility.cpp
+++ b/StorageUtility/Linux/StorageUtility.cpp
@@ -67,12 +67,12 @@ bool IsScsiDeviceBus(udev_device* UdevDevice)
     return false;
 }
 
-bool IsAtaDeviceBus(sStorageAdapterProperty StorageAdapterProperty)
+bool IsAtaDeviceBus(const sStorageAdapterProperty& StorageAdapterProperty)
 {
     return(StorageAdapterProperty.AtaBus);
 }
 
-bool IsScsiDeviceBus(sStorageAdapterProperty StorageAdapterProperty)
+bool IsScsiDeviceBus(const sStorageAdapterProperty& StorageAdapterProperty)
 {
     return(StorageAdapterProperty.ScsiBus);
 }
@@ -136,7 +136,7 @@ eErrorCode GetStorageDevicePaths(std::vector<String>& DevicePaths, std::vector<S
     return(eErrorCode::None);
 }
 
-eErrorCode GetAdapterBus(DeviceHandle& Handle, String SysDevicePath)
+eErrorCode GetAdapterBus(DeviceHandle& Handle, const String& SysDevicePath)
 {
     struct udev *udevObject;
     struct udev_device *udevDevice;
@@ -159,7 +159,7 @@ eErrorCode GetAdapterBus(DeviceHandle& Handle, String SysDevicePath)
     else
     {
         //! Adapter Property is not Ata or Scsi
-        return(eErrorCode::FormatNotSupported);
+        Handle.Bus = eBusType::Undefined;
     }
 
     udev_device_unref(udevDevice);
@@ -168,7 +168,7 @@ eErrorCode GetAdapterBus(DeviceHandle& Handle, String SysDevicePath)
     return(eErrorCode::None);
 }
 
-eErrorCode GetStorageDeviceHandle(const String& DevicePath,String SysDevicePath, DeviceHandle& Handle)
+eErrorCode GetStorageDeviceHandle(const String& DevicePath, const String& SysDevicePath, DeviceHandle& Handle)
 {
     eErrorCode error = eErrorCode::None;
     Handle.Handle = open(DevicePath.c_str(), O_RDONLY|O_NONBLOCK);
@@ -183,7 +183,7 @@ eErrorCode GetStorageDeviceHandle(const String& DevicePath,String SysDevicePath,
     return(error);
 }
 
-eErrorCode GetStorageAdapterProperty(DeviceHandle Handle, sStorageAdapterProperty& AdapterProperty)
+eErrorCode GetStorageAdapterProperty(const DeviceHandle& Handle, sStorageAdapterProperty& AdapterProperty)
 {
     if (eBusType::Ata == Handle.Bus)
     {
@@ -204,14 +204,15 @@ eErrorCode GetStorageAdapterProperty(DeviceHandle Handle, sStorageAdapterPropert
 void CloseDeviceHandle(DeviceHandle& Handle)
 {
     int closeHandleCode = close(Handle.Handle);
-    if (-1 == closeHandleCode)
+    if (INVALID_FILE_DESCRIPTOR == closeHandleCode)
     {
         //! TODO: Catch error for not close Handle of Device
         //! throw std::runtime_error("Close DeviceHandle was not successful");
     }
+    Handle.Bus = eBusType::Undefined;
 }
 
-eErrorCode GetPhysicalDiskNumber(DeviceHandle Handle, U32& PhysicalDiskNumber)
+eErrorCode GetPhysicalDiskNumber(const DeviceHandle& Handle, U32& PhysicalDiskNumber)
 {
     //! TODO Use Device path on Linux system instead PhysicalDiskNumber
 

--- a/StorageUtility/Linux/StorageUtility.h
+++ b/StorageUtility/Linux/StorageUtility.h
@@ -36,14 +36,14 @@ struct sStorageAdapterProperty
 };
 
 eErrorCode GetStorageDevices(std::vector<std::shared_ptr<IDevice>>& Devices, eOnErrorBehavior OnErrorBehavior);
-eErrorCode GetStorageDeviceHandle(const String& DevicePath, String SysDevicePath, DeviceHandle& Handle);
+eErrorCode GetStorageDeviceHandle(const String& DevicePath, const String& SysDevicePath, DeviceHandle& Handle);
 eErrorCode GetStorageDevicePaths(std::vector<String>& DevicePaths, std::vector<String>& SysDevicePaths);
-eErrorCode GetStorageAdapterProperty(DeviceHandle Handle, sStorageAdapterProperty& AdapterProperty);
-eErrorCode GetPhysicalDiskNumber(DeviceHandle Handle, U32& PhysicalDiskNumber);
+eErrorCode GetStorageAdapterProperty(const DeviceHandle& Handle, sStorageAdapterProperty& AdapterProperty);
+eErrorCode GetPhysicalDiskNumber(const DeviceHandle& Handle, U32& PhysicalDiskNumber);
 
 void CloseDeviceHandle(DeviceHandle& Handle);
-bool IsAtaDeviceBus(sStorageAdapterProperty StorageAdapterProperty);
-bool IsScsiDeviceBus(sStorageAdapterProperty StorageAdapterProperty);
+bool IsAtaDeviceBus(const sStorageAdapterProperty& StorageAdapterProperty);
+bool IsScsiDeviceBus(const sStorageAdapterProperty& StorageAdapterProperty);
 
 }
 

--- a/StorageUtility/Windows/Device.cpp
+++ b/StorageUtility/Windows/Device.cpp
@@ -1,6 +1,6 @@
 /*
 <License>
-Copyright 2015 Virtium Technology
+Copyright 2016 Virtium Technology
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -57,9 +57,9 @@ void cDevice::DevicePath(tchar*& DevicePath)
     DevicePath = m_DevDetailData->DevicePath;
 }
 
-eErrorCode cDevice::GetStorageDeviceHandle(const String& DevicePath, HANDLE& Handle)
+eErrorCode cDevice::GetStorageDeviceHandle(const String& DevicePath, DeviceHandle& Handle)
 {
-    Handle =
+    Handle.Handle =
         CreateFile(
         DevicePath.c_str(),
         GENERIC_READ | GENERIC_WRITE,
@@ -70,11 +70,12 @@ eErrorCode cDevice::GetStorageDeviceHandle(const String& DevicePath, HANDLE& Han
         NULL
         );
 
-    if (INVALID_HANDLE_VALUE == Handle)
+    if (INVALID_HANDLE_VALUE == Handle.Handle)
     {
         return(eErrorCode::Io);
     }
 
+    Handle.Bus = eBusType::Undefined;
     return(eErrorCode::None);
 }
 

--- a/StorageUtility/Windows/Device.h
+++ b/StorageUtility/Windows/Device.h
@@ -1,6 +1,6 @@
 /*
 <License>
-Copyright 2015 Virtium Technology
+Copyright 2016 Virtium Technology
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public:
     virtual void DevicePath(tchar*& DevicePath) override;
 
 private:
-    eErrorCode GetStorageDeviceHandle(const String& DevicePath, HANDLE& Handle);
+    eErrorCode GetStorageDeviceHandle(const String& DevicePath, DeviceHandle& Handle);
     void AllocateMemories(const PSP_DEVINFO_DATA& DevInfoData, const PSP_DEVICE_INTERFACE_DATA& DevInterfaceData, const PSP_INTERFACE_DEVICE_DETAIL_DATA& DevDetailData, U32 SizeOfDevDetailData);
     void CopyMemories(const PSP_DEVINFO_DATA& DevInfoData, const PSP_DEVICE_INTERFACE_DATA& DevInterfaceData, const PSP_INTERFACE_DEVICE_DETAIL_DATA& DevDetailData, U32 SizeOfDevDetailData);
     void DeallocateMemories();

--- a/StorageUtility/Windows/StorageUtility.cpp
+++ b/StorageUtility/Windows/StorageUtility.cpp
@@ -144,7 +144,7 @@ eErrorCode EnumerateDevices( sEnumerateDevicesCallback& Callback, const GUID* In
     return( eErrorCode::None );
 }
 
-eErrorCode GetStorageAdapterProperty( HANDLE Handle, sStorageAdapterProperty& AdapterProperty )
+eErrorCode GetStorageAdapterProperty( const DeviceHandle& Handle, sStorageAdapterProperty& AdapterProperty )
 {
     STORAGE_DESCRIPTOR_HEADER storageDescHeader;
 
@@ -155,7 +155,7 @@ eErrorCode GetStorageAdapterProperty( HANDLE Handle, sStorageAdapterProperty& Ad
     DWORD bytesReturned;
     DWORD ret =
         DeviceIoControl(
-                        Handle,
+                        Handle.Handle,
                         IOCTL_STORAGE_QUERY_PROPERTY,
                         &StorageProperty,
                         sizeof(STORAGE_PROPERTY_QUERY),
@@ -179,7 +179,7 @@ eErrorCode GetStorageAdapterProperty( HANDLE Handle, sStorageAdapterProperty& Ad
 
     ret =
         DeviceIoControl(
-                        Handle,
+                        Handle.Handle,
                         IOCTL_STORAGE_QUERY_PROPERTY,
                         &StorageProperty,
                         sizeof(STORAGE_PROPERTY_QUERY),
@@ -203,13 +203,13 @@ eErrorCode GetStorageAdapterProperty( HANDLE Handle, sStorageAdapterProperty& Ad
     return( eErrorCode::None );
 }
 
-eErrorCode GetPhysicalDiskNumber(HANDLE Handle, U32& PhysicalDiskNumber)
+eErrorCode GetPhysicalDiskNumber(const DeviceHandle& Handle, U32& PhysicalDiskNumber)
 {
     STORAGE_DEVICE_NUMBER storageDevice = { 0 };
     DWORD bytesReturned;
     DWORD ret =
         DeviceIoControl(
-                        Handle,
+                        Handle.Handle,
                         IOCTL_STORAGE_GET_DEVICE_NUMBER,
                         NULL,
                         0,
@@ -227,20 +227,22 @@ eErrorCode GetPhysicalDiskNumber(HANDLE Handle, U32& PhysicalDiskNumber)
     return(eErrorCode::None);
 }
 
-void CloseDeviceHandle(HANDLE& Handle)
+void CloseDeviceHandle(DeviceHandle& Handle)
 {
-    if (FALSE == CloseHandle(Handle))
+    if (FALSE == CloseHandle(Handle.Handle))
     {
         //! TODO
         //fprintf(stderr, "\nCloseDeviceHandle was not successful. Error Code: %d", GetLastError());
     }
-    Handle = INVALID_HANDLE_VALUE;
+    Handle.Handle = INVALID_HANDLE_VALUE;
+    Handle.Bus = eBusType::Undefined;
 }
 
-bool IsAtaDeviceBus( sStorageAdapterProperty StorageDeviceProperty )
+bool IsAtaDeviceBus(const sStorageAdapterProperty& StorageDeviceProperty )
 {
     switch ( StorageDeviceProperty.BusType )
     {
+        case BusTypeRAID:
         case BusTypeAta:
         case BusTypeSata:
         {
@@ -253,7 +255,7 @@ bool IsAtaDeviceBus( sStorageAdapterProperty StorageDeviceProperty )
     }
 }
 
-bool IsScsiDeviceBus(sStorageAdapterProperty StorageDeviceProperty)
+bool IsScsiDeviceBus(const sStorageAdapterProperty& StorageDeviceProperty)
 {
     switch (StorageDeviceProperty.BusType)
     {

--- a/StorageUtility/Windows/StorageUtility.h
+++ b/StorageUtility/Windows/StorageUtility.h
@@ -55,13 +55,13 @@ namespace vtStor
         U32   AlignmentMask;
     };
 
-    eErrorCode VTSTOR_API GetStorageAdapterProperty(HANDLE Handle, sStorageAdapterProperty& AdapterProperty);
-    eErrorCode VTSTOR_API GetPhysicalDiskNumber(HANDLE Handle, U32& PhysicalDiskNumber);
+    eErrorCode VTSTOR_API GetStorageAdapterProperty(const DeviceHandle& Handle, sStorageAdapterProperty& AdapterProperty);
+    eErrorCode VTSTOR_API GetPhysicalDiskNumber(const DeviceHandle& Handle, U32& PhysicalDiskNumber);
 
-    void VTSTOR_API CloseDeviceHandle(HANDLE& Handle);
+    void VTSTOR_API CloseDeviceHandle(DeviceHandle& Handle);
 
-    bool VTSTOR_API IsAtaDeviceBus(sStorageAdapterProperty StorageAdapterProperty);
-    bool VTSTOR_API IsScsiDeviceBus(sStorageAdapterProperty StorageAdapterProperty);
+    bool VTSTOR_API IsAtaDeviceBus(const sStorageAdapterProperty& StorageAdapterProperty);
+    bool VTSTOR_API IsScsiDeviceBus(const sStorageAdapterProperty& StorageAdapterProperty);
 }
 
 #endif

--- a/vtStorAta/DriveEnumeratorAta.cpp
+++ b/vtStorAta/DriveEnumeratorAta.cpp
@@ -77,6 +77,7 @@ std::shared_ptr<IDrive> cDriveEnumeratorAta::EnumerateDrive(const std::shared_pt
 
     if ( true == IsAtaDeviceBus( storageAdapterProperty ) )
     {
+        deviceHandle.Bus = eBusType::Ata;
         std::shared_ptr<IDrive> drive = std::make_shared<cDriveAta>(Device, deviceHandle, driveProperties);
 
         return( drive );

--- a/vtStorAtaProtocol/Platform/Windows/ProtocolAtaPassThrough.cpp
+++ b/vtStorAtaProtocol/Platform/Windows/ProtocolAtaPassThrough.cpp
@@ -1,6 +1,6 @@
 /*
 <License>
-Copyright 2015 Virtium Technology
+Copyright 2016 Virtium Technology
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -153,7 +153,7 @@ namespace Protocol
     eErrorCode cAtaPassThrough::IssuePassThroughDirectCommand( const DeviceHandle& Handle, U32& BytesReturned )
     {
         
-        assert( INVALID_HANDLE_VALUE != Handle );
+        assert( INVALID_HANDLE_VALUE != Handle.Handle );
 
         eErrorCode error;
         error = eErrorCode::None;
@@ -162,7 +162,7 @@ namespace Protocol
         DWORD bytesReturned;
         commandSuccessfulFlag = DeviceIoControl
             (
-            Handle,
+            Handle.Handle,
             IOCTL_ATA_PASS_THROUGH_DIRECT,
             &m_AtaPassThrough,
             m_AtaPassThrough.Length,

--- a/vtStorScsi/DriveEnumeratorScsi.cpp
+++ b/vtStorScsi/DriveEnumeratorScsi.cpp
@@ -76,6 +76,7 @@ namespace vtStor
 
         if (true == IsScsiDeviceBus(storageAdapterProperty))
         {
+            deviceHandle.Bus = eBusType::Scsi;
             std::shared_ptr<IDrive> drive = std::make_shared<cDriveScsi>(Device, deviceHandle, driveProperties);
 
             return(drive);

--- a/vtStorScsiProtocol/Platform/Windows/ProtocolScsiPassThrough.cpp
+++ b/vtStorScsiProtocol/Platform/Windows/ProtocolScsiPassThrough.cpp
@@ -1,6 +1,6 @@
 /*
 <License>
-Copyright 2015 Virtium Technology
+Copyright 2016 Virtium Technology
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@ namespace Protocol
     eErrorCode cScsiPassThrough::IssuePassThroughDirectCommand( const DeviceHandle& Handle, U32& BytesReturned )
     {
         
-        assert( INVALID_HANDLE_VALUE != Handle );
+        assert( INVALID_HANDLE_VALUE != Handle.Handle );
 
         eErrorCode error;
         error = eErrorCode::None;
@@ -144,7 +144,7 @@ namespace Protocol
         DWORD bytesReturned;
         commandSuccessfulFlag = DeviceIoControl
             (
-            Handle,
+            Handle.Handle,
             IOCTL_SCSI_PASS_THROUGH_DIRECT,
             &m_ScsiPassThrough,
             m_ScsiPassThrough.Length,


### PR DESCRIPTION
- Define struct DeviceHandle contain 2 elements which have type are HANDLE and eBusType.
  struct sDeviceHandle
  {
      HANDLE Handle;
      eBusType Bus;
  };
  using DeviceHandle = sDeviceHandle;
